### PR TITLE
Closest not available in IE

### DIFF
--- a/assets/js/src/ripplet.js
+++ b/assets/js/src/ripplet.js
@@ -23,7 +23,7 @@ const Ripplet = (() => {
     if (event.button !== 0) {
       return
     }
-    const currentTarget = event.target.closest('.btn, .card-link, .card-primary-action, .list-group-item-action, [data-ripplet]')
+    const currentTarget = $(event.target).closest('.btn, .card-link, .card-primary-action, .list-group-item-action, [data-ripplet]').get(0)
     if (!currentTarget || currentTarget.disabled) {
       return
     }


### PR DESCRIPTION
Closest not available in IE - use jQuery version of closest and retrieve the original element back - using get(0)

Fixes #22