### PR TITLE
Fix IE11 material icons issue

### DIFF
--- a/assets/scss/mixins/_material-icons.scss
+++ b/assets/scss/mixins/_material-icons.scss
@@ -22,7 +22,7 @@
 @mixin set-material-icons {
   @include reset-material-icons;
 
-  font-family: var(--font-family-material-icons); // stylelint-disable-line font-family-no-missing-generic-family-keyword
+  font-family: #{inspect($material-icon-font-family)}; // stylelint-disable-line font-family-no-missing-generic-family-keyword
   font-feature-settings: 'liga';
   font-style: normal;
   font-weight: normal; // stylelint-disable-line font-weight-notation

--- a/assets/scss/utilities/_material-icons.scss
+++ b/assets/scss/utilities/_material-icons.scss
@@ -19,19 +19,19 @@
 }
 
 .material-icons-outlined {
-  font-family: 'Material Icons Outlined', var(--font-family-material-icons); //stylelint-disable-line font-family-no-missing-generic-family-keyword
+  font-family: 'Material Icons Outlined', #{inspect($material-icon-font-family)}; //stylelint-disable-line font-family-no-missing-generic-family-keyword
 }
 
 .material-icons-round {
-  font-family: 'Material Icons Round', var(--font-family-material-icons); //stylelint-disable-line font-family-no-missing-generic-family-keyword
+  font-family: 'Material Icons Round', #{inspect($material-icon-font-family)}; //stylelint-disable-line font-family-no-missing-generic-family-keyword
 }
 
 .material-icons-two-tone {
-  font-family: 'Material Icons Two Tone', var(--font-family-material-icons); //stylelint-disable-line font-family-no-missing-generic-family-keyword
+  font-family: 'Material Icons Two Tone', #{inspect($material-icon-font-family)}; //stylelint-disable-line font-family-no-missing-generic-family-keyword
 }
 
 .material-icons-sharp {
-  font-family: 'Material Icons Sharp', var(--font-family-material-icons); //stylelint-disable-line font-family-no-missing-generic-family-keyword
+  font-family: 'Material Icons Sharp', #{inspect($material-icon-font-family)}; //stylelint-disable-line font-family-no-missing-generic-family-keyword
 }
 
 .material-icons-inline {


### PR DESCRIPTION
IE11 does not show material icons, because material font is included via var (not supported in IE11) - use sass to direct include the value

Fixes: #24 